### PR TITLE
Adds a binary fix that extends the list of items to 255, for Ex Machina and Meridian 113.

### DIFF
--- a/src/commod/game/data.py
+++ b/src/commod/game/data.py
@@ -272,6 +272,20 @@ no_money_in_player_schwarz_patches = [
     )
 ]
 
+more_wares_patches = [
+    BinaryPatch(
+        offset=0x07FD8C, enable_value="FF", disable_value="0A",
+        comment=("Expands the list of goods to 255 items")
+    )
+]
+
+m113_more_wares_patches = [
+    BinaryPatch(
+        offset=0x083BCC, enable_value="FF", disable_value="0A",
+        comment=("Expands the list of goods to 255 items")
+    )
+]
+
 m113_relationship_list_patches = [
     BinaryPatch(
         offset=0x128139, enable_value="540EC400", disable_value="480EC400",

--- a/src/commod/game/mod_auxiliary.py
+++ b/src/commod/game/mod_auxiliary.py
@@ -943,7 +943,8 @@ def patch_memory(target_exe: str, installment: data.SupportedGames) -> list[str]
     return ["minimal_mm_inserts_patched"]
 
 
-def patch_configurables(target_exe: str, exe_options: list[PatcherOptions] | None = None,
+def patch_configurables(target_exe: str, installment: data.SupportedGames,
+                        exe_options: list[PatcherOptions] | None = None,
                         under_windows: bool = True) -> None:
     """Apply binary exe fixes which support configuration."""
     if not exe_options:
@@ -1010,7 +1011,7 @@ def patch_configurables(target_exe: str, exe_options: list[PatcherOptions] | Non
                 patch_offsets(f, data.sell_price_offsets)
 
             if exe_options_config.more_wares is not None:
-                match data.SupportedGames: # тут какая то залупа, нужно сверять с экземпляром игры.
+                match installment:
                     case data.SupportedGames.EXMACHINA:
                         apply_binary_patch(f, data.more_wares_patches,
                                        enable_flag=exe_options_config.more_wares)
@@ -1132,7 +1133,8 @@ def patch_remaster_icon(f: typing.BinaryIO) -> None:
 
 
 def apply_compatches_to_exe(target_exe: str, version_choice: str, build_id: str,
-                            monitor_res: tuple, exe_options: list[PatcherOptions] | None = None,
+                            monitor_res: tuple, installment: data.SupportedGames,
+                            exe_options: list[PatcherOptions] | None = None,
                             under_windows: bool = True) -> list[str]:
     """Apply binary exe fixes, makes related changes to config and global properties.
 
@@ -1236,7 +1238,7 @@ def apply_compatches_to_exe(target_exe: str, version_choice: str, build_id: str,
         # increase_phys_step(game_root_path)
         logger.info("damage coeff patched")
 
-    patch_configurables(target_exe, exe_options, under_windows)
+    patch_configurables(target_exe, installment, exe_options, under_windows)
     return changes_description
 
 

--- a/src/commod/game/mod_auxiliary.py
+++ b/src/commod/game/mod_auxiliary.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
-from typing import Annotated, Any
+from typing import Annotated, Any, ClassVar, Set
 
 from pydantic import (
     BaseModel,
@@ -115,6 +115,7 @@ class MergeDirective(BaseModel, arbitrary_types_allowed = True):
         return self
 
 class PatcherOptions(BaseModel):
+    M113_OPTIONS: ClassVar[set[str]] = {"more_wares"}
     # gameplay
     gravity: Annotated[float, Field(ge=-100, le=-1)] | None = None
     slow_brake: bool | None = None
@@ -138,6 +139,9 @@ class PatcherOptions(BaseModel):
     # m113 specific
     m113_longer_list_of_factions: bool | None = None
 
+    #warelist
+    more_wares: bool | None = None
+
     def is_compatible_with_installment(self, installment: data.SupportedGames) -> bool:
         match installment:
             case data.SupportedGames.EXMACHINA:
@@ -145,7 +149,7 @@ class PatcherOptions(BaseModel):
                            if key.startswith(("m113", "camFov", "g_fixed")))
             case data.SupportedGames.M113:
                 return all(val is None for key, val in self.model_dump().items()
-                           if not key.startswith("m113"))
+                           if not key.startswith("m113") and key not in self.M113_OPTIONS)
             case data.SupportedGames.ARCADE:
                 return all(val is None for val in self.model_dump().values())
 
@@ -1005,6 +1009,14 @@ def patch_configurables(target_exe: str, exe_options: list[PatcherOptions] | Non
                 # changing pointer
                 patch_offsets(f, data.sell_price_offsets)
 
+            if exe_options_config.more_wares is not None:
+                match data.SupportedGames: # тут какая то залупа, нужно сверять с экземпляром игры.
+                    case data.SupportedGames.EXMACHINA:
+                        apply_binary_patch(f, data.more_wares_patches,
+                                       enable_flag=exe_options_config.more_wares)
+                    case data.SupportedGames.M113:
+                        apply_binary_patch(f, data.m113_more_wares_patches,
+                                       enable_flag=exe_options_config.more_wares)
 
         # mapping of offests to value/values needed for binary patch
         configured_offsets: dict[int, Any] = {}

--- a/src/commod/gui/app_widgets.py
+++ b/src/commod/gui/app_widgets.py
@@ -4089,7 +4089,8 @@ class ModInstallWizard(ft.Container):
                                       and opt.patcher_options is not None])
 
             if (not is_comrem_or_patch) and patching_settings:
-                commod.game.mod_auxiliary.patch_configurables(game.target_exe, patching_settings,
+                commod.game.mod_auxiliary.patch_configurables(game.target_exe, mod.installment,
+                                                              patching_settings,
                                                               self.app.context.under_windows)
                 if mod.patcher_options and patching_settings:
                     configured_gravity = None
@@ -4120,6 +4121,7 @@ class ModInstallWizard(ft.Container):
                     "patch" if is_compatch else "remaster",
                     build_id,
                     self.app.context.monitor_res,
+                    mod.installment,
                     patching_settings, # COMPATCHSPECIAL: if is_comrem else None,
                     self.app.context.under_windows)
             elif mod.vanilla_mod and not game.patched_version:


### PR DESCRIPTION
Requires refactoring of the is_compatible_with_installment and is_compatible_with_installment functions.